### PR TITLE
Update rebar.config to reference correct uuid_erl application name

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {erl_opts, [debug_info]}.
 
-{deps, [{uuid_erl, "2.0.2"}]}.
+{deps, [{uuid, "2.0.5", {pkg, uuid_erl}}]}.
 
 {xref_checks, [
     undefined_function_calls, undefined_functions, locals_not_used,


### PR DESCRIPTION
Including this library in a recent Elixir (mix) project produced the following error:

```
Unchecked dependencies for environment test:
* uuid_erl (Hex package)
  could not find an app file at "_build/test/lib/uuid_erl/ebin/uuid_erl.app". Another app file was found in the same directory "_build/test/lib/uuid_erl/ebin/uuid.app", try changing the dependency name to :uuid
```

Changing the `rebar.config` dependencies to the value suggested on hex.pm (https://hex.pm/packages/uuid_erl) resolved the problem.